### PR TITLE
prevent timer from changing size too much

### DIFF
--- a/addons/jamcountdown/countdown.gd
+++ b/addons/jamcountdown/countdown.gd
@@ -103,10 +103,10 @@ func update_countdown_label_text() -> void:
 	var str_seconds
 	
 	if show_time_units:
-		str_days    = str(time_left.day) + "d "    if time_left.day    > 0 else ""
-		str_hours   = str(time_left.hour) + "h "   if time_left.hour   > 0 else ""
-		str_minutes = str(time_left.minute) + "m " if time_left.minute > 0 else ""
-		str_seconds = str(time_left.second) + "s"  if time_left.second > 0 else ""
+		str_days    = "%02d" % time_left.day + "d "    if time_left.day    > 0 else ""
+		str_hours   = "%02d" % time_left.hour + "h "   if time_left.hour   > 0 else ""
+		str_minutes = "%02d" % time_left.minute + "m "
+		str_seconds = "%02d" % time_left.second + "s"
 	else:
 		str_days    = "%02d" % time_left.day    +":"
 		str_hours   = "%02d" % time_left.hour   +":"


### PR DESCRIPTION
I've used the timer in Ludum Dare and I like it because it's simple and does it's job pretty well,
only issues I had is with the timer's size changing all the time when show time units is on, what happens is that when seconds are 1 digit the display number becomes "9" for example instead of "09", which causes the size of the timer to shrink. same thing happens when minutes are 1 digit. and when second or minutes are == 0 which causes them to disappear,
of course this happens with hours and days as well but they don't change often enough for this to be noticeable.

it's up to you whether this change makes sense or not, but I think that the way the timer changes in size all the time is a design flaw, especially when you consider how this issue only happens when show time units is toggled on